### PR TITLE
Response timestamp field as unixtime in seconds

### DIFF
--- a/src/typeDefs/event.ts
+++ b/src/typeDefs/event.ts
@@ -73,7 +73,7 @@ type EventPayload {
   """
   Event timestamp
   """
-  timestamp: DateTime!
+  timestamp: Float!
 
   """
   Event severity level
@@ -128,7 +128,7 @@ type RepetitionPayload {
   """
   Event timestamp
   """
-  timestamp: DateTime!
+  timestamp: Float
 
   """
   Event severity level


### PR DESCRIPTION
API should response event occurrence time as Unix time so that any client could convert in local timezone. 

Repetition's payload may not contain any fields if the value is equal to the original event payload.