### PR TITLE
Fix: project child resolvers now use _id instead of id

### DIFF
--- a/src/models/eventsFactory.js
+++ b/src/models/eventsFactory.js
@@ -38,14 +38,16 @@ class EventsFactory extends Factory {
 
   /**
    * Creates Event instance
-   * @param {string} projectId - project ID
+   * @param {ObjectId} projectId - project ID
    */
   constructor(projectId) {
     super();
+
     if (!projectId) {
       throw new Error('Can not construct Event model, because projectId is not provided');
     }
-    this.projectId = new ObjectID(projectId);
+
+    this.projectId = projectId;
   }
 
   /**

--- a/src/models/userInProject.js
+++ b/src/models/userInProject.js
@@ -8,7 +8,7 @@ const { ObjectID } = require('mongodb');
 class UserInProject {
   /**
    * @param {String} userId - user's identifier
-   * @param {String} projectId - project's identifier
+   * @param {ObjectId} projectId - project's identifier
    */
   constructor(userId, projectId) {
     this.userId = userId;

--- a/src/resolvers/project.js
+++ b/src/resolvers/project.js
@@ -120,7 +120,6 @@ module.exports = {
      * Find project's event
      *
      * @param {ProjectDBScheme} project - result of parent resolver
-     * @param {String} id  - id of project (root resolver)
      * @param {String} eventId - event's identifier
      *
      * @returns {Event}
@@ -153,7 +152,6 @@ module.exports = {
      * Returns events count that wasn't seen on project
      *
      * @param {ProjectDBScheme} project - result of parent resolver
-     * @param {String} projectId - project identifier
      * @param {Object} data - additional data. In this case it is empty
      * @param {User} user - authorized user
      *

--- a/src/resolvers/project.js
+++ b/src/resolvers/project.js
@@ -119,16 +119,17 @@ module.exports = {
     /**
      * Find project's event
      *
+     * @param {ProjectDBScheme} project - result of parent resolver
      * @param {String} id  - id of project (root resolver)
      * @param {String} eventId - event's identifier
      *
      * @returns {Event}
      */
-    async event({ id }, { id: eventId }) {
-      const factory = new EventsFactory(id);
+    async event(project, { id: eventId }) {
+      const factory = new EventsFactory(project._id);
       const event = await factory.findById(eventId);
 
-      event.projectId = id;
+      event.projectId = project._id;
 
       return event;
     },
@@ -136,14 +137,14 @@ module.exports = {
     /**
      * Find project events
      *
-     * @param {String} id  - id of project (root resolver)
+     * @param {ProjectDBScheme} project - result of parent resolver
      * @param {number} limit - query limit
      * @param {number} skip - query skip
      * @param {Context.user} user - current authorized user {@see ../index.js}
      * @returns {Event[]}
      */
-    async events({ id }, { limit, skip }) {
-      const factory = new EventsFactory(id);
+    async events(project, { limit, skip }) {
+      const factory = new EventsFactory(project._id);
 
       return factory.find({}, limit, skip);
     },
@@ -151,15 +152,16 @@ module.exports = {
     /**
      * Returns events count that wasn't seen on project
      *
+     * @param {ProjectDBScheme} project - result of parent resolver
      * @param {String} projectId - project identifier
      * @param {Object} data - additional data. In this case it is empty
      * @param {User} user - authorized user
      *
      * @return {Promise<number>}
      */
-    async unreadCount({ id: projectId }, data, { user }) {
-      const eventsFactory = new EventsFactory(projectId);
-      const userInProject = new UserInProject(user.id, projectId);
+    async unreadCount(project, data, { user }) {
+      const eventsFactory = new EventsFactory(project._id);
+      const userInProject = new UserInProject(user.id, project._id);
       const lastVisit = await userInProject.getLastVisit();
 
       return eventsFactory.getUnreadCount(lastVisit);
@@ -168,14 +170,14 @@ module.exports = {
     /**
      * Returns recent Events grouped by day
      *
-     * @param {ResolverObj} _obj
+     * @param {ProjectDBScheme} project - result of parent resolver
      * @param {Number} limit - limit for events count
      * @param {Number} skip - certain number of documents to skip
      *
      * @return {Promise<RecentEventSchema[]>}
      */
-    async recentEvents({ id: projectId }, { limit, skip }) {
-      const factory = new EventsFactory(projectId);
+    async recentEvents(project, { limit, skip }) {
+      const factory = new EventsFactory(project._id);
 
       return factory.findRecent(limit, skip);
     },


### PR DESCRIPTION
The bug caused by [changing](https://github.com/codex-team/hawk.api.nodejs/pull/158/files#diff-6900e62d5b011b1ae4ee4b04bf2eefeeR20) project resolver to dataloaders by #158 