### PR TITLE
create EncodedJSON scalar type and use it on events field

### DIFF
--- a/src/resolvers/encodedJSON.ts
+++ b/src/resolvers/encodedJSON.ts
@@ -1,0 +1,15 @@
+import { GraphQLScalarType } from 'graphql';
+
+const GraphQLEncodedJSON = new GraphQLScalarType({
+  name: 'EncodedJSON',
+  description: 'Represents JSON objects encoded (or not) in string format',
+  serialize(value: string | object): object {
+    if (typeof value === 'string') {
+      return JSON.parse(value);
+    }
+
+    return value;
+  },
+});
+
+export default GraphQLEncodedJSON;

--- a/src/resolvers/encodedJSON.ts
+++ b/src/resolvers/encodedJSON.ts
@@ -1,5 +1,9 @@
 import { GraphQLScalarType } from 'graphql';
 
+/**
+ * Custom GraphQL Scalar type
+ * Represents JSON objects encoded (or not) in string format
+ */
 const GraphQLEncodedJSON = new GraphQLScalarType({
   name: 'EncodedJSON',
   description: 'Represents JSON objects encoded (or not) in string format',

--- a/src/typeDefs/event.ts
+++ b/src/typeDefs/event.ts
@@ -133,12 +133,12 @@ type EventPayload {
   """
   Any additional data of Event
   """
-  context: JSONObject
+  context: EncodedJSON
 
   """
   Custom data provided by project users
   """
-  addons: JSONObject
+  addons: EncodedJSON
 }
 
 """
@@ -188,12 +188,12 @@ type RepetitionPayload {
   """
   Any additional data of Event
   """
-  context: JSONObject
+  context: EncodedJSON
 
   """
   Custom data provided by project users
   """
-  addons: JSONObject
+  addons: EncodedJSON
 }
 
 """

--- a/src/typeDefs/index.ts
+++ b/src/typeDefs/index.ts
@@ -73,6 +73,11 @@ const rootSchema = gql`
   scalar JSONObject
 
   """
+  Represents JSON objects encoded (or not) in string format
+  """
+  scalar EncodedJSON
+
+  """
   Supported languages for data
   """
   enum Languages {

--- a/test/resolvers/encodedJSON.test.ts
+++ b/test/resolvers/encodedJSON.test.ts
@@ -16,7 +16,7 @@ const FIXTURE = {
     false: false,
     null: null,
   },
-  array: ['string', 3, 3.14, true, false, null],
+  array: ['string', 3, 3.14, true, false, null, 'string.with.dot'],
 };
 
 type RootType = typeof FIXTURE

--- a/test/resolvers/encodedJSON.test.ts
+++ b/test/resolvers/encodedJSON.test.ts
@@ -1,0 +1,75 @@
+import { graphql, GraphQLObjectType, GraphQLSchema } from 'graphql';
+import GraphQLEncodedJSON from '../../src/resolvers/encodedJSON';
+
+const FIXTURE = {
+  string: 'string',
+  int: 3,
+  float: 3.14,
+  true: true,
+  false: false,
+  null: null,
+  object: {
+    string: 'string',
+    int: 3,
+    float: 3.14,
+    true: true,
+    false: false,
+    null: null,
+  },
+  array: ['string', 3, 3.14, true, false, null],
+};
+
+type RootType = typeof FIXTURE
+
+/**
+ * Creates schema for testing purposes
+ * @returns GraphQLSchema
+ */
+function createSchema(): GraphQLSchema {
+  return new GraphQLSchema({
+    query: new GraphQLObjectType({
+      name: 'Query',
+      fields: {
+        rootValue: {
+          type: GraphQLEncodedJSON,
+          resolve: (obj): RootType => obj,
+        },
+      },
+    }),
+  });
+}
+describe('GraphQLEncodedJSON', () => {
+  const schema = createSchema();
+
+  describe('serialize', () => {
+    it('should support serialization from object', async () => {
+      const { data, errors } = await graphql(
+        schema,
+        `
+           query {
+            rootValue
+          }
+        `,
+        FIXTURE
+      );
+
+      expect(data?.rootValue).toEqual(FIXTURE);
+      expect(errors).toBeUndefined();
+    });
+
+    it('should support serialization from string', async () => {
+      const { data, errors } = await graphql(
+        schema,
+        `
+          query {
+            rootValue
+          }
+        `,
+        JSON.stringify(FIXTURE)
+      );
+
+      expect(data?.rootValue).toEqual(FIXTURE);
+      expect(errors).toBeUndefined();
+    });
+  });
+});


### PR DESCRIPTION
see https://github.com/codex-team/hawk.workers/pull/145
так как некоторые поля у ивента теперь могут быть закодированы, то надо парить JSON, прежде чем отдать клиенту данные