### PR TITLE
Fixes for payment widget work

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -20,6 +20,9 @@ JWT_SECRET_ACCESS_TOKEN=belarus
 # JWT secret for project's tokens (used in catcher)
 JWT_SECRET_PROJECT_TOKEN=qwerty
 
+# JWT secret for signing tokens for processing billing requests
+JWT_SECRET_BILLING_CHECKSUM=checksum_secret
+
 # Option to enable playground (if true playground will be available at /graphql route)
 PLAYGROUND_ENABLE=false
 

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "apollo-server-express": "^2.14.2",
     "argon2": "^0.26.2",
     "axios": "^0.21.1",
+    "body-parser": "^1.19.0",
     "codex-accounting-sdk": "https://github.com/codex-team/codex-accounting-sdk/",
     "copyfiles": "^2.1.1",
     "dataloader": "^2.0.0",

--- a/src/billing/cloudpayments.ts
+++ b/src/billing/cloudpayments.ts
@@ -168,7 +168,7 @@ export default class CloudPaymentsWebhooks {
         status: BusinessOperationStatus.Pending,
         payload: {
           workspaceId: workspace._id,
-          amount: body.Amount,
+          amount: +body.Amount,
           userId: member._id,
           tariffPlanId: plan._id,
         },
@@ -180,7 +180,7 @@ export default class CloudPaymentsWebhooks {
       return;
     }
 
-    telegram.sendMessage(`✅ [Billing / Check] All checks passed successfully &laquo;${workspace.name}&raquo;`, TelegramBotURLs.Money)
+    telegram.sendMessage(`✅ [Billing / Check] All checks passed successfully *${workspace.name}*`, TelegramBotURLs.Money)
       .catch(e => console.error('Error while sending message to Telegram: ' + e));
     HawkCatcher.send(new Error('[Billing / Check] All checks passed successfully'), body);
 
@@ -295,7 +295,7 @@ export default class CloudPaymentsWebhooks {
       return;
     }
 
-    telegram.sendMessage(`✅ [Billing / Pay] Payment passed successfully for &laquo;${workspace.name}&raquo;`, TelegramBotURLs.Money)
+    telegram.sendMessage(`✅ [Billing / Pay] Payment passed successfully for *${workspace.name}*`, TelegramBotURLs.Money)
       .catch(e => console.error('Error while sending message to Telegram: ' + e));
 
     res.json({

--- a/src/billing/cloudpayments.ts
+++ b/src/billing/cloudpayments.ts
@@ -57,10 +57,10 @@ export default class CloudPaymentsWebhooks {
    * @param res - Express response object
    */
   private async composePayment(req: express.Request, res: express.Response): Promise<void> {
-    const { workspaceId, tariffIdPlan } = req.query as Record<string, string>;
+    const { workspaceId, tariffPlanId } = req.query as Record<string, string>;
     const userId = req.context.user.id;
 
-    if (!workspaceId || !tariffIdPlan || !userId) {
+    if (!workspaceId || !tariffPlanId || !userId) {
       this.sendError(res, 1, `[Billing / Compose payment] No workspace, tariff plan or user id in request body`, req.query);
 
       return;
@@ -72,7 +72,7 @@ export default class CloudPaymentsWebhooks {
 
     try {
       workspace = await this.getWorkspace(req, workspaceId);
-      tariffPlan = await this.getPlan(req, tariffIdPlan);
+      tariffPlan = await this.getPlan(req, tariffPlanId);
       user = await this.getUser(req, userId);
     } catch (e) {
       this.sendError(res, 1, `[Billing / Compose payment] Can't get data from Database ${e.toString()}`, req.query);

--- a/src/billing/cloudpayments.ts
+++ b/src/billing/cloudpayments.ts
@@ -83,10 +83,13 @@ export default class CloudPaymentsWebhooks {
     const invoiceId = `CDX ${new Date().toISOString()} ${tariffPlan.name}`;
 
     res.send({
-      workspaceId: workspace._id,
-      userId: user._id,
+      workspaceId: workspace._id.toString(),
+      userId: user._id.toString(),
       invoiceId: invoiceId,
-      plan: tariffPlan,
+      plan: {
+        name: tariffPlan.name,
+        monthlyCharge: tariffPlan.monthlyCharge,
+      },
       currency: 'USD',
       checksum: 'some hash',
     });

--- a/src/billing/cloudpayments.ts
+++ b/src/billing/cloudpayments.ts
@@ -87,6 +87,7 @@ export default class CloudPaymentsWebhooks {
       userId: user._id.toString(),
       invoiceId: invoiceId,
       plan: {
+        id: tariffPlan._id.toString(),
         name: tariffPlan.name,
         monthlyCharge: tariffPlan.monthlyCharge,
       },

--- a/src/billing/cloudpayments.ts
+++ b/src/billing/cloudpayments.ts
@@ -209,7 +209,7 @@ export default class CloudPaymentsWebhooks {
     try {
       data = this.parseAndVerifyData(body.Data);
     } catch (e) {
-      this.sendError(res, CheckCodes.PAYMENT_COULD_NOT_BE_ACCEPTED, `[Billing / Pay] Can't parse data from body`, body);
+      this.sendError(res, CheckCodes.SUCCESS, `[Billing / Pay] Can't parse data from body`, body);
 
       return;
     }

--- a/src/billing/cloudpayments.ts
+++ b/src/billing/cloudpayments.ts
@@ -108,7 +108,9 @@ export default class CloudPaymentsWebhooks {
     const data = body.Data;
     const context = req.context;
 
+    console.log(req);
     console.log(req.body);
+    console.log(req.query);
     console.log(data);
 
     let workspace: WorkspaceModel;

--- a/src/billing/cloudpayments.ts
+++ b/src/billing/cloudpayments.ts
@@ -108,6 +108,9 @@ export default class CloudPaymentsWebhooks {
     const data = body.Data;
     const context = req.context;
 
+    console.log(req.body);
+    console.log(data);
+
     let workspace: WorkspaceModel;
     let member: ConfirmedMemberDBScheme;
     let plan: PlanDBScheme;

--- a/src/billing/cloudpayments.ts
+++ b/src/billing/cloudpayments.ts
@@ -87,7 +87,7 @@ export default class CloudPaymentsWebhooks {
 
       return;
     }
-    const invoiceId = this.generateInvoiceId(tariffPlan);
+    const invoiceId = this.generateInvoiceId(tariffPlan, workspace);
 
     let checksum;
 
@@ -119,11 +119,12 @@ export default class CloudPaymentsWebhooks {
    * Generates invoice id for payment
    *
    * @param tariffPlan - tariff plan to generate invoice id
+   * @param workspace - workspace data to generate invoice id
    */
-  private generateInvoiceId(tariffPlan: PlanDBScheme): string {
+  private generateInvoiceId(tariffPlan: PlanDBScheme, workspace: WorkspaceModel): string {
     const now = new Date();
 
-    return `CDX ${now.getDate()}/${now.getMonth() + 1} ${tariffPlan.name}`;
+    return `${workspace.name} ${now.getDate()}/${now.getMonth() + 1} ${tariffPlan.name}`;
   }
 
   /**

--- a/src/billing/cloudpayments.ts
+++ b/src/billing/cloudpayments.ts
@@ -20,10 +20,11 @@ import {
   PayloadOfWorkspacePlanPurchase,
   PlanDBScheme
 } from 'hawk.types';
+import { PENNY_MULTIPLIER, AccountType, Currency } from 'codex-accounting-sdk';
 import WorkspaceModel from '../models/workspace';
 import HawkCatcher from '@hawk.so/nodejs';
 import { publish } from '../rabbitmq';
-import { AccountType, Currency } from 'codex-accounting-sdk';
+
 import sendNotification from '../utils/personalNotifications';
 import { PlanProlongationNotificationTask, SenderWorkerTaskType } from '../types/personalNotifications';
 import BusinessOperationModel from '../models/businessOperation';
@@ -168,7 +169,7 @@ export default class CloudPaymentsWebhooks {
         status: BusinessOperationStatus.Pending,
         payload: {
           workspaceId: workspace._id,
-          amount: +body.Amount,
+          amount: +body.Amount * PENNY_MULTIPLIER,
           userId: member._id,
           tariffPlanId: plan._id,
         },
@@ -256,13 +257,13 @@ export default class CloudPaymentsWebhooks {
 
       await context.accounting.payOnce({
         accountId: accountId,
-        amount: tariffPlan.monthlyCharge,
+        amount: tariffPlan.monthlyCharge * PENNY_MULTIPLIER,
         description: `Account replenishment to pay for the tariff plan with id ${tariffPlan._id}. CloudPayments transaction ID: ${body.TransactionId}`,
       });
 
       await context.accounting.purchase({
         accountId,
-        amount: tariffPlan.monthlyCharge,
+        amount: tariffPlan.monthlyCharge * PENNY_MULTIPLIER,
         description: `Charging for tariff plan with id ${tariffPlan._id}. CloudPayments transaction ID: ${body.TransactionId}`,
       });
     } catch (e) {

--- a/src/billing/types/request.ts
+++ b/src/billing/types/request.ts
@@ -136,7 +136,7 @@ export interface CheckRequest {
   /**
    * An arbitrary set of parameters passed to the transaction
    */
-  Data?: PlanProlongationPayload;
+  Data?: string;
 }
 
 /**
@@ -279,7 +279,7 @@ export interface PayRequest {
   /**
    * An arbitrary set of parameters passed to the transaction
    */
-  Data?: PlanProlongationPayload;
+  Data?: string;
 
   /**
    * Card token for repeated payments without entering details
@@ -551,4 +551,8 @@ export interface RecurrentRequest {
    * Date and time of the next payment in the UTC time zone
    */
   NextTransactionDate?: Date;
+}
+
+export interface WebhookData {
+  checksum: string;
 }

--- a/src/billing/types/request.ts
+++ b/src/billing/types/request.ts
@@ -553,6 +553,12 @@ export interface RecurrentRequest {
   NextTransactionDate?: Date;
 }
 
+/**
+ * Data that we expect in the request
+ */
 export interface WebhookData {
+  /**
+   * Checksum for validating request and getting data from it
+   */
   checksum: string;
 }

--- a/src/billing/types/request.ts
+++ b/src/billing/types/request.ts
@@ -14,7 +14,7 @@ export interface CheckRequest {
   /**
    * Payment amount from the payment parameters
    */
-  Amount: number;
+  Amount: string;
 
   /**
    * Currency: RUB/USD
@@ -152,7 +152,7 @@ export interface PayRequest {
   /**
    * Payment amount from the payment parameters
    */
-  Amount: number;
+  Amount: string;
 
   /**
    * Currency: RUB/USD

--- a/src/index.ts
+++ b/src/index.ts
@@ -74,7 +74,6 @@ class HawkAPI {
   constructor() {
     this.app.use(express.json());
     this.app.use(bodyParser.urlencoded({ extended: false }));
-    this.app.use(bodyParser.json());
     this.app.use('/uploads', express.static(`./${process.env.UPLOADS_DIR || 'uploads'}`));
     this.app.use('/static', express.static(`./static`));
     this.app.use('/voyager', voyagerMiddleware({ endpointUrl: '/graphql' }));

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,6 +19,7 @@ import HawkCatcher from '@hawk.so/nodejs';
 import { express as voyagerMiddleware } from 'graphql-voyager/middleware';
 import Accounting from 'codex-accounting-sdk';
 import Billing from './billing';
+import bodyParser from 'body-parser';
 
 import UploadImageDirective from './directives/uploadImageDirective';
 import RequireAuthDirective from './directives/requireAuthDirective';
@@ -72,6 +73,8 @@ class HawkAPI {
    */
   constructor() {
     this.app.use(express.json());
+    this.app.use(bodyParser.urlencoded({ extended: false }));
+    this.app.use(bodyParser.json());
     this.app.use('/uploads', express.static(`./${process.env.UPLOADS_DIR || 'uploads'}`));
     this.app.use('/static', express.static(`./static`));
     this.app.use('/voyager', voyagerMiddleware({ endpointUrl: '/graphql' }));

--- a/src/resolvers/billingNew.ts
+++ b/src/resolvers/billingNew.ts
@@ -65,7 +65,7 @@ export default {
      * @param payload - result from resolver above
      */
     __resolveType(payload: BusinessOperationPayloadType): string {
-      if ('userId' in payload) {
+      if ('cardPan' in payload) {
         return 'PayloadOfDepositByUser';
       }
 

--- a/src/typeDefs/plans.ts
+++ b/src/typeDefs/plans.ts
@@ -18,7 +18,7 @@ export default gql`
     """
     Monthly charge for plan
     """
-    monthlyCharge: Long!
+    monthlyCharge: Int!
 
     """
     Events limit for plan

--- a/src/utils/checksumService.ts
+++ b/src/utils/checksumService.ts
@@ -1,0 +1,48 @@
+import { PlanProlongationPayload } from 'hawk.types';
+import jwt, { Secret } from 'jsonwebtoken';
+import { WebhookData } from '../billing/types/request';
+
+/**
+ * Helper class for working with checksums
+ */
+class ChecksumService {
+  /**
+   * Generates checksum for processing billing requests
+   *
+   * @param data - data for processing billing request
+   */
+  public async generateChecksum(data: PlanProlongationPayload): Promise<string> {
+    return jwt.sign(
+      data,
+      process.env.JWT_SECRET_BILLING_CHECKSUM as Secret,
+      { expiresIn: '30m' }
+    );
+  }
+
+  /**
+   * Parses checksum from request data and returns data from it
+   *
+   * @param data - data to parse
+   */
+  public parseAndVerifyData(data: string | undefined): PlanProlongationPayload {
+    const parsedData = JSON.parse(data || '{}') as WebhookData;
+    const checksum = parsedData.checksum;
+
+    const payload = jwt.verify(checksum, process.env.JWT_SECRET_BILLING_CHECKSUM as Secret) as PlanProlongationPayload;
+
+    /**
+     * Filter unnecessary fields from JWT payload (e.g. "iat")
+     */
+    const { tariffPlanId, workspaceId, userId } = payload;
+
+    return {
+      tariffPlanId,
+      workspaceId,
+      userId,
+    };
+  }
+}
+
+const checksumService = new ChecksumService();
+
+export default checksumService;

--- a/test/integration/api.env
+++ b/test/integration/api.env
@@ -22,6 +22,9 @@ JWT_SECRET_ACCESS_TOKEN=belarus
 # JWT secret for project's tokens (used in catcher)
 JWT_SECRET_PROJECT_TOKEN=qwerty
 
+# JWT secret for signing tokens for processing billing requests
+JWT_SECRET_BILLING_CHECKSUM=checksum_secret
+
 # Option to enable playground (if true playground will be available at /graphql route)
 PLAYGROUND_ENABLE=true
 

--- a/test/integration/cases/billing/check.test.ts
+++ b/test/integration/cases/billing/check.test.ts
@@ -11,7 +11,7 @@ const transactionId = 880555;
  * Basic check request
  */
 const mainRequest: CheckRequest = {
-  Amount: 20,
+  Amount: '20',
   CardExpDate: '06/25',
   CardFirstSix: '578946',
   CardLastFour: '5367',
@@ -179,7 +179,7 @@ describe('Check webhook', () => {
      */
     const data: CheckRequest = {
       ...mainRequest,
-      Amount: 20.45,
+      Amount: '20.45',
       Data: JSON.stringify({
         checksum: await checksumService.generateChecksum({
           workspaceId: workspace._id.toString(),

--- a/test/integration/cases/billing/check.test.ts
+++ b/test/integration/cases/billing/check.test.ts
@@ -3,6 +3,7 @@ import { CheckCodes, CheckRequest } from '../../../../src/billing/types';
 import { CardType, Currency, OperationStatus, OperationType } from '../../../../src/billing/types/enums';
 import mongodb, { Collection, ObjectId } from 'mongodb';
 import { BusinessOperationDBScheme, BusinessOperationStatus, ConfirmedMemberDBScheme, PlanDBScheme, UserDBScheme, WorkspaceDBScheme } from 'hawk.types';
+import checksumService from '../../../../src/utils/checksumService';
 
 const transactionId = 880555;
 
@@ -98,11 +99,13 @@ describe('Check webhook', () => {
      */
     const data: CheckRequest = {
       ...mainRequest,
-      Data: {
-        workspaceId: '5fe383b0126d28907780641b',
-        userId: admin._id.toString(),
-        tariffPlanId: plan._id.toString(),
-      },
+      Data: JSON.stringify({
+        checksum: await checksumService.generateChecksum({
+          workspaceId: '5fe383b0126d28907780641b',
+          userId: admin._id.toString(),
+          tariffPlanId: plan._id.toString(),
+        }),
+      }),
     };
 
     const apiResponse = await apiInstance.post('/billing/check', data);
@@ -116,11 +119,13 @@ describe('Check webhook', () => {
      */
     const data: CheckRequest = {
       ...mainRequest,
-      Data: {
-        workspaceId: workspace._id.toString(),
-        userId: user._id.toString(),
-        tariffPlanId: plan._id.toString(),
-      },
+      Data: JSON.stringify({
+        checksum: await checksumService.generateChecksum({
+          workspaceId: workspace._id.toString(),
+          userId: user._id.toString(),
+          tariffPlanId: plan._id.toString(),
+        }),
+      }),
     };
 
     const apiResponse = await apiInstance.post('/billing/check', data);
@@ -134,11 +139,13 @@ describe('Check webhook', () => {
      */
     const data: CheckRequest = {
       ...mainRequest,
-      Data: {
-        workspaceId: workspace._id.toString(),
-        userId: member._id.toString(),
-        tariffPlanId: plan._id.toString(),
-      },
+      Data: JSON.stringify({
+        checksum: await checksumService.generateChecksum({
+          workspaceId: workspace._id.toString(),
+          userId: member._id.toString(),
+          tariffPlanId: plan._id.toString(),
+        }),
+      }),
     };
 
     const apiResponse = await apiInstance.post('/billing/check', data);
@@ -152,11 +159,13 @@ describe('Check webhook', () => {
      */
     const data: CheckRequest = {
       ...mainRequest,
-      Data: {
-        workspaceId: workspace._id.toString(),
-        userId: admin._id.toString(),
-        tariffPlanId: '5fe383b0126d28007780641b',
-      },
+      Data: JSON.stringify({
+        checksum: await checksumService.generateChecksum({
+          workspaceId: workspace._id.toString(),
+          userId: admin._id.toString(),
+          tariffPlanId: '5fe383b0126d28007780641b',
+        }),
+      }),
     };
 
     const apiResponse = await apiInstance.post('/billing/check', data);
@@ -171,11 +180,13 @@ describe('Check webhook', () => {
     const data: CheckRequest = {
       ...mainRequest,
       Amount: 20.45,
-      Data: {
-        workspaceId: workspace._id.toString(),
-        userId: admin._id.toString(),
-        tariffPlanId: plan._id.toString(),
-      },
+      Data: JSON.stringify({
+        checksum: await checksumService.generateChecksum({
+          workspaceId: workspace._id.toString(),
+          userId: admin._id.toString(),
+          tariffPlanId: plan._id.toString(),
+        }),
+      }),
     };
 
     const apiResponse = await apiInstance.post('/billing/check', data);
@@ -189,11 +200,13 @@ describe('Check webhook', () => {
      */
     const data: CheckRequest = {
       ...mainRequest,
-      Data: {
-        workspaceId: workspace._id.toString(),
-        userId: admin._id.toString(),
-        tariffPlanId: plan._id.toString(),
-      },
+      Data: JSON.stringify({
+        checksum: await checksumService.generateChecksum({
+          workspaceId: workspace._id.toString(),
+          userId: admin._id.toString(),
+          tariffPlanId: plan._id.toString(),
+        }),
+      }),
     };
 
     const apiResponse = await apiInstance.post('/billing/check', data);

--- a/test/integration/cases/billing/pay.test.ts
+++ b/test/integration/cases/billing/pay.test.ts
@@ -101,7 +101,7 @@ describe('Pay webhook', () => {
 
   beforeAll(async () => {
     validPayRequestData = {
-      Amount: 10,
+      Amount: '10',
       CardExpDate: '06/25',
       CardFirstSix: '578946',
       CardLastFour: '5367',
@@ -286,9 +286,7 @@ describe('Pay webhook', () => {
       type: SenderWorkerTaskType.PlanProlongation,
       payload: {
         endpoint: 'test@hawk.so',
-        userId: user._id.toString(),
-        workspaceId: workspace._id.toString(),
-        tariffPlanId: tariffPlan._id.toString(),
+        ...planProlongationPayload,
       },
     };
 

--- a/test/integration/yarn.lock
+++ b/test/integration/yarn.lock
@@ -1590,7 +1590,7 @@ has@^1.0.3:
 
 "hawk.types@https://github.com/codex-team/hawk.types":
   version "0.0.1"
-  resolved "https://github.com/codex-team/hawk.types#7fb5d13a419c85201747f529c540c1f2940e6ace"
+  resolved "https://github.com/codex-team/hawk.types#1c00f49e20f53b7e2c582630a051dacea12ffd1d"
   dependencies:
     "@types/mongodb" "^3.5.34"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1910,7 +1910,7 @@ bluebird@^3.5.2:
   resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.7.2.tgz#9f229c15be272454ffa973ace0dbee79a1b0c36f"
   integrity sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==
 
-body-parser@1.19.0, body-parser@^1.18.3:
+body-parser@1.19.0, body-parser@^1.18.3, body-parser@^1.19.0:
   version "1.19.0"
   resolved "https://registry.yarnpkg.com/body-parser/-/body-parser-1.19.0.tgz#96b2709e57c9c4e09a6fd66a8fd979844f69f08a"
   integrity sha512-dhEPs72UPbDnAQJ9ZKMNTP6ptJaionhP5cBb541nXPlW60Jepo9RV/a4fX4XWW9CuFNK22krhrj1+rgzifNCsw==


### PR DESCRIPTION
closes #285 

- поправлен формат сообщений от cloudpayments (оказывается там Data в виде строки приходит)
- добавил body-parser чтобы парсить post запросы от CloudPayments
- сделал checksum в виде JWT токена, в котором зашиты все нужные данные, поэтому в Data теперь нужен только он