### PR TITLE
fix(event-repetition): return null for 404 event

### DIFF
--- a/src/models/eventsFactory.js
+++ b/src/models/eventsFactory.js
@@ -117,7 +117,7 @@ class EventsFactory extends Factory {
    * Find event by id
    *
    * @param {string|ObjectID} id - event's id
-   * @returns {Event}
+   * @returns {Event|null}
    */
   async findById(id) {
     const searchResult = await this.getCollection(this.TYPES.EVENTS)
@@ -125,7 +125,7 @@ class EventsFactory extends Factory {
         _id: new ObjectID(id),
       });
 
-    return new Event(searchResult);
+    return searchResult ? new Event(searchResult) : null;
   }
 
   /**

--- a/src/resolvers/project.js
+++ b/src/resolvers/project.js
@@ -195,6 +195,10 @@ module.exports = {
       const factory = new EventsFactory(project._id);
       const event = await factory.findById(eventId);
 
+      if (!event) {
+        return null;
+      }
+
       event.projectId = project._id;
 
       return event;


### PR DESCRIPTION
If you will change `eventId` in the URL, you will get `Event = null`

## Before 

<img width="521" alt="image" src="https://user-images.githubusercontent.com/3684889/118705602-19ba3f80-b821-11eb-9406-cd6f96221175.png">

## After

<img width="1353" alt="image" src="https://user-images.githubusercontent.com/3684889/118705517-0018f800-b821-11eb-9091-f5d51f5125b4.png">
