### PR TITLE
[Feature] Join by invite hash

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -23,6 +23,9 @@ JWT_SECRET_PROJECT_TOKEN=qwerty
 # JWT secret for signing tokens for processing billing requests
 JWT_SECRET_BILLING_CHECKSUM=checksum_secret
 
+# Hash salt for generate private invite links
+INVITE_LINK_HASH_SALT=secret_hash_salt
+
 # Option to enable playground (if true playground will be available at /graphql route)
 PLAYGROUND_ENABLE=false
 

--- a/src/models/project.ts
+++ b/src/models/project.ts
@@ -385,9 +385,15 @@ export default class ProjectModel extends AbstractModel<ProjectDBScheme> impleme
   public async remove(): Promise<void> {
     await this.collection.deleteOne({ _id: this._id });
 
-    /**
-     * Remove users in project collection
-     */
-    await this.dbConnection.collection('users-in-project:' + this._id).drop();
+    try {
+      /**
+       * Remove users in project collection
+       */
+      await this.dbConnection.collection('users-in-project:' + this._id)
+        .drop();
+    } catch (error) {
+      console.log(`Can't remove collection "users-in-project:${this._id}" because it doesn't exist.`);
+      console.log(error);
+    }
   }
 }

--- a/src/models/workspacesFactory.ts
+++ b/src/models/workspacesFactory.ts
@@ -83,12 +83,23 @@ export default class WorkspacesFactory extends AbstractModelFactory<WorkspaceDBS
   }
 
   /**
-   * Returns workspace bu its subscription id
+   * Returns workspace by its subscription id
    *
    * @param subscriptionId - subscription id from payment system
    */
   public async findBySubscriptionId(subscriptionId: string): Promise<WorkspaceModel | null> {
     const workspaceData = await this.collection.findOne({ subscriptionId });
+
+    return workspaceData && new WorkspaceModel(workspaceData);
+  }
+
+  /**
+   * Returns workspace by its invite hash
+   *
+   * @param inviteHash - workspace invite hash
+   */
+  public async findByInviteHash(inviteHash: string): Promise<WorkspaceModel | null> {
+    const workspaceData = await this.collection.findOne({ inviteHash });
 
     return workspaceData && new WorkspaceModel(workspaceData);
   }

--- a/src/resolvers/workspace.js
+++ b/src/resolvers/workspace.js
@@ -112,7 +112,7 @@ module.exports = {
 
       const linkHash = crypto
         .createHash('sha256')
-        .update(`${workspaceId}:${userEmail}:${process.env.HASH_SALT}`)
+        .update(`${workspaceId}:${userEmail}:${process.env.INVITE_LINK_HASH_SALT}`)
         .digest('hex');
 
       const inviteLink = `${process.env.GARAGE_URL}/join/${workspaceId}/${linkHash}`;
@@ -169,7 +169,7 @@ module.exports = {
 
       const hash = crypto
         .createHash('sha256')
-        .update(`${workspaceId}:${currentUser.email}:${process.env.HASH_SALT}`)
+        .update(`${workspaceId}:${currentUser.email}:${process.env.INVITE_LINK_HASH_SALT}`)
         .digest('hex');
 
       if (hash !== inviteHash) {

--- a/src/resolvers/workspace.js
+++ b/src/resolvers/workspace.js
@@ -126,6 +126,30 @@ module.exports = {
     },
 
     /**
+     * Join to workspace by invite link with invite hash
+     *
+     * @param {ResolverObj} _obj - object that contains the result returned from the resolver on the parent field
+     * @param {String} inviteHash - hash passed to the invite link
+     * @param {UserInContext} user - current authorized user {@see ../index.js}
+     * @param {ContextFactories} factories - factories for working with models
+     *
+     * @return {Promise<boolean>} - true if operation is successful
+     */
+    async joinByInviteLink(_obj, { inviteHash }, { user, factories }) {
+      const currentUser = await factories.usersFactory.findById(user.id);
+      const workspace = await factories.workspacesFactory.findByInviteHash(inviteHash);
+
+      if (await workspace.getMemberInfo(user.id)) {
+        throw new ApolloError('You are already member of this workspace');
+      }
+
+      await workspace.addMember(currentUser._id.toString());
+      await currentUser.addWorkspace(workspace._id.toString());
+
+      return true;
+    },
+
+    /**
      * Confirm user invitation
      *
      * @param {ResolverObj} _obj - object that contains the result returned from the resolver on the parent field

--- a/src/resolvers/workspace.js
+++ b/src/resolvers/workspace.js
@@ -133,7 +133,7 @@ module.exports = {
      * @param {UserInContext} user - current authorized user {@see ../index.js}
      * @param {ContextFactories} factories - factories for working with models
      *
-     * @return {Promise<boolean>} - true if operation is successful
+     * @return {Promise<object>} - true if operation is successful
      */
     async joinByInviteLink(_obj, { inviteHash }, { user, factories }) {
       const currentUser = await factories.usersFactory.findById(user.id);
@@ -146,7 +146,10 @@ module.exports = {
       await workspace.addMember(currentUser._id.toString());
       await currentUser.addWorkspace(workspace._id.toString());
 
-      return true;
+      return {
+        recordId: workspace._id.toString(),
+        record: workspace,
+      };
     },
 
     /**
@@ -158,7 +161,7 @@ module.exports = {
      * @param {UserInContext} user - current authorized user {@see ../index.js}
      * @param {ContextFactories} factories - factories for working with models
      *
-     * @return {Promise<boolean>} - true if operation is successful
+     * @return {Promise<object>} - true if operation is successful
      */
     async confirmInvitation(_obj, { inviteHash, workspaceId }, { user, factories }) {
       const currentUser = await factories.usersFactory.findById(user.id);
@@ -181,7 +184,10 @@ module.exports = {
         await currentUser.addWorkspace(workspaceId);
       }
 
-      return true;
+      return {
+        recordId: workspace._id.toString(),
+        record: workspace,
+      };
     },
 
     /**

--- a/src/typeDefs/workspace.ts
+++ b/src/typeDefs/workspace.ts
@@ -178,6 +178,16 @@ export default gql`
     ): Boolean! @requireAdmin
 
     """
+    Join to workspace by invite link with hash
+    """
+    joinByInviteLink(
+      """
+      Workspace invite hash from link
+      """
+      inviteHash: String!
+    ): Boolean! @requireAuth
+
+    """
     Confirm invitation to workspace
     Returns true if operation is successful
     """

--- a/src/typeDefs/workspace.ts
+++ b/src/typeDefs/workspace.ts
@@ -4,7 +4,7 @@ export default gql`
   """
   Response of updated workspace mutations
   """
-  type UpdateWorkspacePayload {
+  type UpdateWorkspaceResponse {
     """
     Id of updated workspace
     """
@@ -200,7 +200,7 @@ export default gql`
       Workspace invite hash from link
       """
       inviteHash: String!
-    ): UpdateWorkspacePayload! @requireAuth
+    ): UpdateWorkspaceResponse! @requireAuth
 
     """
     Confirm invitation to workspace
@@ -216,7 +216,7 @@ export default gql`
       Id of the workspace to which the user was invited
       """
       workspaceId: ID!
-    ): UpdateWorkspacePayload! @requireAuth
+    ): UpdateWorkspaceResponse! @requireAuth
 
     """
     Grant admin permissions

--- a/src/typeDefs/workspace.ts
+++ b/src/typeDefs/workspace.ts
@@ -2,6 +2,21 @@ import { gql } from 'apollo-server-express';
 
 export default gql`
   """
+  Responce of updated workspace mutations
+  """
+  type UpdateWorkspacePayload {
+    """
+    Id of updated workspace
+    """
+    recordId: ID!
+
+    """
+    Updated workspace object
+    """
+    record: Workspace!
+  }
+
+  """
   Confirmed member data in workspace
   """
   type ConfirmedMember {
@@ -185,7 +200,7 @@ export default gql`
       Workspace invite hash from link
       """
       inviteHash: String!
-    ): Boolean! @requireAuth
+    ): UpdateWorkspacePayload! @requireAuth
 
     """
     Confirm invitation to workspace
@@ -201,7 +216,7 @@ export default gql`
       Id of the workspace to which the user was invited
       """
       workspaceId: ID!
-    ): Boolean! @requireAuth
+    ): UpdateWorkspacePayload! @requireAuth
 
     """
     Grant admin permissions

--- a/src/typeDefs/workspace.ts
+++ b/src/typeDefs/workspace.ts
@@ -195,9 +195,11 @@ export default gql`
       """
       Hash from invitation link
       """
-      inviteHash: String
+      inviteHash: String!
 
-      "Id of the workspace to which the user was invited"
+      """
+      Id of the workspace to which the user was invited
+      """
       workspaceId: ID!
     ): Boolean! @requireAuth
 


### PR DESCRIPTION
Now api has two separates mutations:
- `joinByInviteLink` - for joining to a workspace by "public" invite link with invite hash. For example, `https://garage.hawk.so/join/my-invite-hash`;
- `confirmInvitation` - for joining to a workspace by "private" invite link from, for example, email message.