### PR TITLE
generate integration id if not any

### DIFF
--- a/src/resolvers/project.js
+++ b/src/resolvers/project.js
@@ -149,11 +149,14 @@ module.exports = {
         throw new ApolloError('There is no project with that id:', id);
       }
 
-      const encodedIntegrationToken = ProjectModel.generateIntegrationToken(project.integrationId);
+      const integrationId = project.integrationId || ProjectModel.generateIntegrationId();
+
+      const encodedIntegrationToken = ProjectModel.generateIntegrationToken(integrationId);
 
       try {
         const updatedProject = await project.updateProject({
           token: encodedIntegrationToken,
+          integrationId,
         });
 
         return {


### PR DESCRIPTION
у старых проектов нет integration id. Поэтому чтобы обновить токен, им нужно его сгенерировать. Этот реквест позволит генерировать проекту этот id если его нет