### PR TITLE
fix(profile-settings): notifications settings dropping after profile update

### DIFF
--- a/migrations/20220218172429-user-notifications-fix.js
+++ b/migrations/20220218172429-user-notifications-fix.js
@@ -1,0 +1,43 @@
+/**
+ * This migration fixes dropped user notifications settings which can happen after profile update
+ * @see https://github.com/codex-team/hawk.api.nodejs/issues/395
+ */
+module.exports = {
+  /**
+   * Add dropped 'isEnabled' and 'whatToReceive' fields
+   */
+  async up(db) {
+    await db
+      .getCollection('users')
+      .updateMany(
+        {
+          'notifications.channels.email.isEnabled': { $exists: false }
+        },
+        {
+          $set: {
+            'notifications.channels.email.isEnabled': true,
+            'notifications.whatToReceive': { IssueAssigning: true, WeeklyDigest: true, SystemMessages: true }
+          }
+        }
+      );
+  },
+
+  /**
+   * Rollback adding of dropped 'isEnabled' and 'whatToReceive' fields
+   */
+  async down(db) {
+    await db
+      .getCollection('users')
+      .updateMany(
+        {
+          'notifications.channels.email.isEnabled': { $exists: false}
+        },
+        {
+          $unset: {
+            'notifications.channels.email.isEnabled': '',
+            'notifications.whatToReceive': ''
+          }
+        }
+      );
+  }
+};

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hawk.api",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "main": "index.ts",
   "license": "UNLICENSED",
   "scripts": {

--- a/src/models/user.ts
+++ b/src/models/user.ts
@@ -230,7 +230,6 @@ export default class UserModel extends AbstractModel<UserDBScheme> implements Us
 
   /**
    * Update user profile data
-   * @param userId - user ID
    * @param  user – user object
    */
   public async updateProfile(user: Partial<UserDBScheme>): Promise<void> {
@@ -239,6 +238,7 @@ export default class UserModel extends AbstractModel<UserDBScheme> implements Us
       email: true,
       image: true,
       notifications: true,
+      'notifications.channels.email.endpoint': true
     })) {
       throw new Error('User object has invalid properties');
     }
@@ -249,6 +249,7 @@ export default class UserModel extends AbstractModel<UserDBScheme> implements Us
         user
       );
     } catch (e) {
+      console.error(e);
       throw new Error('Can\'t update profile');
     }
   }

--- a/src/resolvers/user.ts
+++ b/src/resolvers/user.ts
@@ -192,11 +192,7 @@ export default {
         const options: {[key: string]: string | object} = {
           name,
           email,
-          notifications: {
-            channels: {
-              email: { endpoint: email },
-            },
-          },
+          'notifications.channels.email.endpoint': email,
         };
 
         if (image) {
@@ -205,7 +201,7 @@ export default {
 
         await currentUser!.updateProfile(options);
       } catch (err) {
-        throw new ApolloError('Something went wrong');
+        throw new ApolloError(err);
       }
 
       return true;


### PR DESCRIPTION
Currently, after profile update, all the notifications settings will be overridden by `{ email : 'user email' }` 

This PR fixes that

<img width="309" alt="image" src="https://user-images.githubusercontent.com/3684889/154734785-bb1fb4bb-d01f-4688-9c3a-4be4cc436d35.png">


Resolves #395 

