### PR TITLE
fix: added permission rules to interact with project data

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hawk.api",
-  "version": "1.1.5",
+  "version": "1.1.6",
   "main": "index.ts",
   "license": "UNLICENSED",
   "scripts": {

--- a/src/resolvers/project.js
+++ b/src/resolvers/project.js
@@ -20,12 +20,12 @@ module.exports = {
     /**
      * Returns project's Model
      * @param {ResolverObj} _obj
-     * @param {String} id - project id
+     * @param {String} projectId - project id
      * @param {ContextFactories} factories - factories for working with models
      * @return {Promise<ProjectDBScheme>}
      */
-    async project(_obj, { id }, { factories }) {
-      return factories.projectsFactory.findById(id);
+    async project(_obj, { projectId }, { factories }) {
+      return factories.projectsFactory.findById(projectId);
     },
   },
   Mutation: {

--- a/src/typeDefs/project.ts
+++ b/src/typeDefs/project.ts
@@ -95,7 +95,7 @@ type Project {
   """
   Project's Event
   """
-  event(id: ID!): Event @requireAuth
+  event(id: ID!): Event
 
   """
   Project events
@@ -106,7 +106,7 @@ type Project {
 
     "Certain number of documents to skip"
     skip: Int = 0
-  ): [Event!] @requireAuth
+  ): [Event!]
 
   """
   Returns recent events grouped by day
@@ -123,7 +123,7 @@ type Project {
 
     "Event marks by which events should be sorted"
     filters: EventsFiltersInput
-  ): RecentEvents @requireAuth
+  ): RecentEvents
   """
   Return events that occurred after a certain timestamp
   """
@@ -137,23 +137,23 @@ type Project {
     User's local timezone offset in minutes
     """
     timezoneOffset: Int! = 0
-  ): [ChartDataItem] @requireAuth
+  ): [ChartDataItem]
   """
   Returns number of unread events
   """
-  unreadCount: Int! @requireAuth
+  unreadCount: Int!
 
   """
   Project notification settings
   """
-  notifications: [ProjectNotificationsRule] @requireAuth
+  notifications: [ProjectNotificationsRule]
 }
 
 extend type Query {
   """
   Returns project info
   """
-  project("Project id" id: ID!): Project @requireAuth
+  project("Project id" projectId: ID!): Project @requireUserInWorkspace
 }
 
 extend type Mutation {
@@ -199,7 +199,7 @@ extend type Mutation {
     Project image
     """
     image: Upload @uploadImage
-  ): Project! @requireAuth
+  ): Project! @requireAdmin
 
   """
   Generates new project integration token by id
@@ -227,6 +227,6 @@ extend type Mutation {
     project ID
     """
     projectId: ID!
-  ): DateTime! @requireAuth
+  ): DateTime! @requireUserInWorkspace
 }
 `;


### PR DESCRIPTION
1. Change `project()` query identifier key from `id` to `projectId`
2. Added `@requireUserInWorkspace` directive for `project()` queries