### PR TITLE
Chore: Add user-provided context field to search filter

### DIFF
--- a/src/models/eventsFactory.js
+++ b/src/models/eventsFactory.js
@@ -207,6 +207,12 @@ class EventsFactory extends Factory {
               $options: 'i',
             },
           },
+          {
+            'event.payload.context': {
+              $regex: escapedSearch,
+              $options: 'i',
+            },
+          },
         ],
       }
       : {};


### PR DESCRIPTION
### Summary
Extended the search functionality to include user-provided data in the `event.payload.context` field.

### Changes
- Updated the MongoDB query to apply regex search to `event.payload.context` alongside existing fields (`title` and `backtrace.file`).
- Allows users to find events based on additional context they provide.

### Motivation
This change improves search relevance and flexibility by indexing user-supplied context data.