### PR TITLE
feat(search): enable search by addons field

### DIFF
--- a/src/models/eventsFactory.js
+++ b/src/models/eventsFactory.js
@@ -221,6 +221,12 @@ class EventsFactory extends Factory {
               $options: 'i',
             },
           },
+          {
+            'event.payload.addons': {
+              $regex: escapedSearch,
+              $options: 'i',
+            },
+          },
         ],
       }
       : {};


### PR DESCRIPTION
Added the ability to search by `event.payload.addons`. Improves discoverability of events associated with specific addons.