### PR TITLE
fix(): release expectations

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hawk.api",
-  "version": "1.1.34",
+  "version": "1.1.35",
   "main": "index.ts",
   "license": "UNLICENSED",
   "scripts": {

--- a/src/typeDefs/event.ts
+++ b/src/typeDefs/event.ts
@@ -53,7 +53,7 @@ type Release {
   """
   Release commits
   """
-  commits: [Commit!]!
+  commits: [Commit!]
 }
 
 """


### PR DESCRIPTION
fixes this issue
https://garage.hawk.so/project/5e5fb64c3e3a9d37fa33739d/event/6848418b8f93dcc91a4110e9/overview

Commits are null most of the time, so resolver should be able to return null as release.commits
<img width="515" height="145" alt="image" src="https://github.com/user-attachments/assets/9cfead87-9f46-4bf9-97f8-d6a10ed9e974" />
