### PR TITLE
Handle card-link fail cases in CloudPayments

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hawk.api",
-  "version": "1.4.12",
+  "version": "1.4.13",
   "main": "index.ts",
   "license": "BUSL-1.1",
   "scripts": {

--- a/src/billing/cloudpayments.ts
+++ b/src/billing/cloudpayments.ts
@@ -523,7 +523,7 @@ subscription id: ${body.SubscriptionId}`;
      */
     if (!data.isCardLinkOperation) {
       if (!data.tariffPlanId) {
-        this.sendError(res, FailCodes.SUCCESS, `[Billing / Fail] No plan id in request body`, body);
+        this.sendError(res, FailCodes.SUCCESS, `[Billing / Fail] No tariffPlanId in request body`, body);
 
         return;
       }

--- a/src/billing/cloudpayments.ts
+++ b/src/billing/cloudpayments.ts
@@ -22,8 +22,7 @@ import {
   BusinessOperationType,
   ConfirmedMemberDBScheme,
   PayloadOfWorkspacePlanPurchase,
-  PlanDBScheme,
-  PlanProlongationPayload
+  PlanDBScheme
 } from '@hawk.so/types';
 import WorkspaceModel from '../models/workspace';
 import HawkCatcher from '@hawk.so/nodejs';
@@ -487,7 +486,7 @@ subscription id: ${body.SubscriptionId}`;
    */
   private async fail(req: express.Request, res: express.Response): Promise<void> {
     const body: FailRequest = req.body;
-    let data: PlanProlongationPayload;
+    let data: PaymentData;
 
     console.log('💎 CloudPayments /fail request', body);
 
@@ -507,10 +506,27 @@ subscription id: ${body.SubscriptionId}`;
      * @todo handle card linking and update business operation status
      */
 
-    if (!data.workspaceId || !data.userId || !data.tariffPlanId) {
-      this.sendError(res, FailCodes.SUCCESS, `[Billing / Fail] No workspace or user id or plan id in request body`, body);
+    if (!data.workspaceId) {
+      this.sendError(res, FailCodes.SUCCESS, `[Billing / Fail] No workspace id in request body`, body);
 
       return;
+    }
+
+    if (!data.userId) {
+      this.sendError(res, FailCodes.SUCCESS, `[Billing / Fail] No user id in request body`, body);
+
+      return;
+    }
+
+    /**
+     * In card linking mode tariff plan id is taken from workspace.
+     */
+    if (!data.isCardLinkOperation) {
+      if (!data.tariffPlanId) {
+        this.sendError(res, FailCodes.SUCCESS, `[Billing / Fail] No plan id in request body`, body);
+
+        return;
+      }
     }
 
     try {

--- a/test/integration/cases/billing/fail.test.ts
+++ b/test/integration/cases/billing/fail.test.ts
@@ -2,10 +2,11 @@ import { apiInstance } from '../../utils';
 import { FailCodes, FailRequest } from '../../../../src/billing/types';
 import { CardType, Currency, OperationType, ReasonCode, ReasonCodesTranscript } from '../../../../src/billing/types/enums';
 import { Collection, ObjectId, Db } from 'mongodb';
-import { BusinessOperationDBScheme, BusinessOperationStatus, PlanDBScheme, BusinessOperationType, UserDBScheme, WorkspaceDBScheme, UserNotificationType, PlanProlongationPayload } from '@hawk.so/types';
+import { BusinessOperationDBScheme, BusinessOperationStatus, PlanDBScheme, BusinessOperationType, UserDBScheme, WorkspaceDBScheme, UserNotificationType } from '@hawk.so/types';
 import { WorkerPaths } from '../../../../src/rabbitmq';
 import { PaymentFailedNotificationTask, SenderWorkerTaskType } from '../../../../src/types/personalNotifications';
 import checksumService from '../../../../src/utils/checksumService';
+import jwt, { Secret } from 'jsonwebtoken';
 import type { Global } from '@jest/types';
 
 declare var global: Global.Global;
@@ -51,6 +52,7 @@ const tariffPlan: PlanDBScheme = {
 };
 
 const planProlongationPayload = {
+  isCardLinkOperation: false,
   userId: user._id.toString(),
   workspaceId: workspace._id.toString(),
   tariffPlanId: tariffPlan._id.toString(),
@@ -215,6 +217,35 @@ describe('Fail webhook', () => {
       expect(message && JSON.parse(message.content.toString())).toStrictEqual(expectedLimiterTask);
       expect(apiResponse.data.code).toBe(FailCodes.SUCCESS);
     });
+
+    test('Should change business operation status to rejected for card linking payload without tariff plan id', async () => {
+      const apiResponse = await apiInstance.post('/billing/fail', {
+        ...validRequest,
+        Data: JSON.stringify({
+          checksum: await checksumService.generateChecksum({
+            isCardLinkOperation: true,
+            userId: user._id.toString(),
+            workspaceId: workspace._id.toString(),
+            nextPaymentDate: new Date().toString(),
+          }),
+          cloudPayments: {
+            recurrent: {
+              interval: 'Month',
+              period: 1,
+              amount: 100,
+              startDate: new Date().toISOString(),
+            },
+          },
+        }),
+      });
+
+      const updatedBusinessOperation = await businessOperationsCollection.findOne({
+        transactionId: transactionId.toString(),
+      });
+
+      expect(apiResponse.data.code).toBe(FailCodes.SUCCESS);
+      expect(updatedBusinessOperation?.status).toBe(BusinessOperationStatus.Rejected);
+    });
   });
 
   describe('With invalid request', () => {
@@ -236,6 +267,7 @@ describe('Fail webhook', () => {
         ...validRequest,
         Data: JSON.stringify({
           checksum: await checksumService.generateChecksum({
+            isCardLinkOperation: false,
             userId: '',
             workspaceId: workspace._id.toString(),
             tariffPlanId: tariffPlan._id.toString(),
@@ -250,6 +282,34 @@ describe('Fail webhook', () => {
       });
 
       expect(apiResponse.data.code).toBe(FailCodes.SUCCESS);
+      expect(updatedBusinessOperation?.status).toBe(BusinessOperationStatus.Pending);
+    });
+
+    test('Should not change business operation status for non-card-link payload without tariff plan id', async () => {
+      const invalidChecksum = jwt.sign({
+        isCardLinkOperation: false,
+        userId: user._id.toString(),
+        workspaceId: workspace._id.toString(),
+        shouldSaveCard: false,
+        nextPaymentDate: new Date().toString(),
+      }, process.env.JWT_SECRET_BILLING_CHECKSUM as Secret, { expiresIn: '30m' });
+
+      const apiResponse = await apiInstance.post('/billing/fail', {
+        ...validRequest,
+        Data: JSON.stringify({
+          checksum: invalidChecksum,
+        }),
+      });
+
+      const updatedBusinessOperation = await businessOperationsCollection.findOne({
+        transactionId: transactionId.toString(),
+      });
+      const message = await global.rabbitChannel.get(WorkerPaths.Email.queue, {
+        noAck: true,
+      });
+
+      expect(apiResponse.data.code).toBe(FailCodes.SUCCESS);
+      expect(message).toBeFalsy();
       expect(updatedBusinessOperation?.status).toBe(BusinessOperationStatus.Pending);
     });
   });

--- a/test/integration/cases/billing/fail.test.ts
+++ b/test/integration/cases/billing/fail.test.ts
@@ -52,7 +52,6 @@ const tariffPlan: PlanDBScheme = {
 };
 
 const planProlongationPayload = {
-  isCardLinkOperation: false,
   userId: user._id.toString(),
   workspaceId: workspace._id.toString(),
   tariffPlanId: tariffPlan._id.toString(),
@@ -267,7 +266,6 @@ describe('Fail webhook', () => {
         ...validRequest,
         Data: JSON.stringify({
           checksum: await checksumService.generateChecksum({
-            isCardLinkOperation: false,
             userId: '',
             workspaceId: workspace._id.toString(),
             tariffPlanId: tariffPlan._id.toString(),


### PR DESCRIPTION
Update CloudPayments /fail handling

Allow missing tariffPlanId when isCardLinkOperation is true (tariff is taken from workspace). Adjust error responses accordingly.

Improve logs: separate statements