### PR TITLE
Perf/api mongo projections

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hawk.api",
-  "version": "1.5.2",
+  "version": "1.5.3",
   "main": "index.ts",
   "license": "BUSL-1.1",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hawk.api",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "main": "index.ts",
   "license": "BUSL-1.1",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hawk.api",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "main": "index.ts",
   "license": "BUSL-1.1",
   "scripts": {

--- a/src/dataLoaders.ts
+++ b/src/dataLoaders.ts
@@ -68,12 +68,19 @@ export default class DataLoaders {
    * Batching function for resolving entities from their ids
    * @param collectionName - collection name to get entities
    * @param ids - ids for resolving
+   * @param projection - optional mongo projection to limit returned fields
    */
   private async batchByIds<T extends { _id: ObjectId }>(
     collectionName: string,
-    ids: ReadonlyArray<string>
+    ids: ReadonlyArray<string>,
+    projection?: Record<string, 0 | 1>
   ): Promise<(WithId<T> | null)[]> {
-    return this.batchByField<T, '_id'>(collectionName, '_id', ids.map(id => new ObjectId(id)));
+    return this.batchByField<T, '_id'>(
+      collectionName,
+      '_id',
+      ids.map(id => new ObjectId(id)),
+      projection
+    );
   }
 
   /**
@@ -81,6 +88,7 @@ export default class DataLoaders {
    * @param collectionName - collection name to get entities
    * @param fieldName - field name to resolve
    * @param values - values for resolving
+   * @param projection - optional mongo projection to limit returned fields
    */
   private async batchByField<
     T extends Record<string, any>,
@@ -88,7 +96,8 @@ export default class DataLoaders {
   >(
     collectionName: string,
     fieldName: FieldType,
-    values: ReadonlyArray<T[FieldType]>
+    values: ReadonlyArray<T[FieldType]>,
+    projection?: Record<string, 0 | 1>
   ): Promise<(WithId<T> | null)[]> {
     type Doc = WithId<T>;
     const valuesMap = new Map<string, FieldType>();
@@ -99,9 +108,10 @@ export default class DataLoaders {
 
     const queryResult = await this.dbConnection
       .collection<T>(collectionName)
-      .find({
-        [fieldName]: { $in: Array.from(valuesMap.values()) },
-      } as any)
+      .find(
+        { [fieldName]: { $in: Array.from(valuesMap.values()) } } as any,
+        projection ? { projection } : {}
+      )
       .toArray();
 
     /**

--- a/src/dataLoaders.ts
+++ b/src/dataLoaders.ts
@@ -68,19 +68,12 @@ export default class DataLoaders {
    * Batching function for resolving entities from their ids
    * @param collectionName - collection name to get entities
    * @param ids - ids for resolving
-   * @param projection - optional mongo projection to limit returned fields
    */
   private async batchByIds<T extends { _id: ObjectId }>(
     collectionName: string,
-    ids: ReadonlyArray<string>,
-    projection?: Record<string, 0 | 1>
+    ids: ReadonlyArray<string>
   ): Promise<(WithId<T> | null)[]> {
-    return this.batchByField<T, '_id'>(
-      collectionName,
-      '_id',
-      ids.map(id => new ObjectId(id)),
-      projection
-    );
+    return this.batchByField<T, '_id'>(collectionName, '_id', ids.map(id => new ObjectId(id)));
   }
 
   /**
@@ -88,7 +81,6 @@ export default class DataLoaders {
    * @param collectionName - collection name to get entities
    * @param fieldName - field name to resolve
    * @param values - values for resolving
-   * @param projection - optional mongo projection to limit returned fields
    */
   private async batchByField<
     T extends Record<string, any>,
@@ -96,8 +88,7 @@ export default class DataLoaders {
   >(
     collectionName: string,
     fieldName: FieldType,
-    values: ReadonlyArray<T[FieldType]>,
-    projection?: Record<string, 0 | 1>
+    values: ReadonlyArray<T[FieldType]>
   ): Promise<(WithId<T> | null)[]> {
     type Doc = WithId<T>;
     const valuesMap = new Map<string, FieldType>();
@@ -108,10 +99,9 @@ export default class DataLoaders {
 
     const queryResult = await this.dbConnection
       .collection<T>(collectionName)
-      .find(
-        { [fieldName]: { $in: Array.from(valuesMap.values()) } } as any,
-        projection ? { projection } : {}
-      )
+      .find({
+        [fieldName]: { $in: Array.from(valuesMap.values()) },
+      } as any)
       .toArray();
 
     /**

--- a/src/models/eventsFactory.js
+++ b/src/models/eventsFactory.js
@@ -403,9 +403,14 @@ class EventsFactory extends Factory {
       return { 'event.assignee': String(assignee) };
     })();
 
-    /** When false, $limit can move before the $lookups. */
+    /**
+     * These filters match joined event.* fields, so their $match must run
+     * after the lookups. With none set, $limit can move before the lookups
+     * and skip joining rows we'd drop anyway (~8.8s).
+     * Trim search to match searchFilter's own condition.
+     */
     const hasContentFilters =
-      escapedSearch.length > 0 ||
+      search.trim().length > 0 ||
       Boolean(release) ||
       Boolean(assignee) ||
       Object.keys(matchFilter).length > 0;

--- a/src/models/eventsFactory.js
+++ b/src/models/eventsFactory.js
@@ -403,6 +403,17 @@ class EventsFactory extends Factory {
       return { 'event.assignee': String(assignee) };
     })();
 
+    /** When false, $limit can move before the $lookups. */
+    const hasContentFilters =
+      escapedSearch.length > 0 ||
+      Boolean(release) ||
+      Boolean(assignee) ||
+      Object.keys(matchFilter).length > 0;
+
+    if (!hasContentFilters) {
+      pipeline.push({ $limit: limit + 1 });
+    }
+
     pipeline.push(
       /**
        * Left outer join original event on groupHash field
@@ -434,20 +445,24 @@ class EventsFactory extends Factory {
           path: '$repetition',
           preserveNullAndEmptyArrays: true,
         },
-      },
-      {
-        $match: {
-          ...matchFilter,
-          ...searchFilter,
-          ...releaseFilter,
-          ...assigneeFilter,
-        },
-      },
-      { $limit: limit + 1 },
-      {
-        $unset: 'groupHash',
       }
     );
+
+    if (hasContentFilters) {
+      pipeline.push(
+        {
+          $match: {
+            ...matchFilter,
+            ...searchFilter,
+            ...releaseFilter,
+            ...assigneeFilter,
+          },
+        },
+        { $limit: limit + 1 }
+      );
+    }
+
+    pipeline.push({ $unset: 'groupHash' });
 
     const cursor = this.getCollection(this.TYPES.DAILY_EVENTS).aggregate(pipeline);
     const result = await cursor.toArray();


### PR DESCRIPTION
findDailyEventsPortion: $limit before $lookups when no content filter (was the 8.8s prod aggregation). DataLoader batch helpers gain optional projection arg.