### PR TITLE
feat(events): expose per-repetition occurrence count via GraphQL

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hawk.api",
-  "version": "1.5.3",
+  "version": "1.5.4",
   "main": "index.ts",
   "license": "BUSL-1.1",
   "scripts": {

--- a/src/models/eventsFactory.js
+++ b/src/models/eventsFactory.js
@@ -33,6 +33,7 @@ const ChartType = {
  * @property {Number} originalTimestamp - UNIX timestmap of the original event
  * @property {String} originalEventId - id of the original event
  * @property {String} projectId - id of the project, which repetition it is
+ * @property {Number} [count] - number of real repetition occurrences; absent means single occurrence
  */
 
 /**
@@ -1120,6 +1121,7 @@ class EventsFactory extends Factory {
       originalEventId: event._id,
       timestamp: repetition.timestamp,
       payload: composeEventPayloadByRepetition(event.payload, repetition),
+      count: repetition.count,
       projectId: this.projectId,
     };
   }

--- a/src/typeDefs/event.ts
+++ b/src/typeDefs/event.ts
@@ -272,6 +272,14 @@ type Event {
   totalCount: Int!
 
   """
+  Number of real occurrences this single repetition represents. Null for the
+  original event and for ordinary repetitions (both mean "single occurrence")
+  — distinct from totalCount, which is the group's grand total across all
+  repetitions.
+  """
+  count: Int
+
+  """
   User assigneed to the event
   """
   assignee: User

--- a/test/models/eventsFactory-compose-repetition.test.ts
+++ b/test/models/eventsFactory-compose-repetition.test.ts
@@ -1,0 +1,78 @@
+import '../../src/env-test';
+
+jest.mock('../../src/redisHelper', () => ({
+  __esModule: true,
+  default: {
+    getInstance: () => ({}),
+  },
+}));
+
+jest.mock('../../src/services/chartDataService', () => ({
+  __esModule: true,
+  default: jest.fn().mockImplementation(function () {
+    return {};
+  }),
+}));
+
+jest.mock('../../src/dataLoaders', () => ({
+  createProjectEventsByIdLoader: () => ({}),
+}));
+
+jest.mock('../../src/mongo', () => ({
+  databases: {
+    events: {
+      collection: jest.fn(),
+    },
+  },
+}));
+
+// eslint-disable-next-line @typescript-eslint/no-var-requires, @typescript-eslint/no-explicit-any
+const EventsFactory = require('../../src/models/eventsFactory') as any;
+
+describe('EventsFactory._composeEventWithRepetition', () => {
+  const projectId = '507f1f77bcf86cd799439011';
+  let factory: any;
+
+  const baseEvent = {
+    _id: 'original-event-id',
+    groupHash: 'hash',
+    totalCount: 5,
+    timestamp: 1000,
+    payload: { title: 'Test error' },
+  };
+
+  beforeEach(() => {
+    factory = new EventsFactory(projectId);
+  });
+
+  it('should not set count when there is no repetitions', () => {
+    const result = factory._composeEventWithRepetition(baseEvent, null);
+
+    expect(result.count).toBeUndefined();
+  });
+
+  it('should expose repetition count on the composed result when present', () => {
+    const repetition = {
+      _id: 'repetition-id',
+      timestamp: 2000,
+      delta: null,
+      count: 7,
+    };
+
+    const result = factory._composeEventWithRepetition(baseEvent, repetition);
+
+    expect(result.count).toBe(7);
+  });
+
+  it('should leave repetition count undefined when count is not present', () => {
+    const repetition = {
+      _id: 'repetition-id',
+      timestamp: 2000,
+      delta: null,
+    };
+
+    const result = factory._composeEventWithRepetition(baseEvent, repetition);
+
+    expect(result.count).toBeUndefined();
+  });
+});


### PR DESCRIPTION
- typeDefs: add nullable count: Int on Event (also used for repetitions
  via RepetitionsPortion), distinct from totalCount
- eventsFactory: _composeEventWithRepetition exposes repetition.count
  on the composed result

Depends on @hawk.so/types publishing RepetitionDBScheme.count
(codex-team/hawk.types#76) and codex-team/hawk.workers#573.