### PR TITLE
feat(plans): add @allowAnon directive to plans field in GraphQL schema

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hawk.api",
-  "version": "1.5.3",
+  "version": "1.5.4",
   "main": "index.ts",
   "license": "BUSL-1.1",
   "scripts": {

--- a/src/typeDefs/plans.ts
+++ b/src/typeDefs/plans.ts
@@ -40,6 +40,6 @@ export default gql`
     """
     Gets available Hawk tariff plans
     """
-    plans: [Plan!]!
+    plans: [Plan!]! @allowAnon
   }
 `;


### PR DESCRIPTION
## Summary
Allow anonymous access to the plans query by adding @allowAnon.

This lets demo and unauthenticated clients load live tariff plans from MongoDB instead of using mocked plans in Garage.